### PR TITLE
Update ext.php

### DIFF
--- a/ext.php
+++ b/ext.php
@@ -10,16 +10,23 @@
 namespace imkingdavid\customusertitle;
 
 /**
- * @ignore
- */
-if (!defined('IN_PHPBB'))
-{
-	exit;
-}
-
-/**
- * Main extension class for Custom User Title extension.
- */
+* Extension class for custom enable/disable/purge actions
+*/
 class ext extends \phpbb\extension\base
 {
+	/**
+	* Check whether or not the extension can be enabled.
+	* The current phpBB version should meet or exceed
+	* the minimum version required by this extension:
+	*
+	* Requires phpBB 3.1.3 due to usage of http_exception.
+	*
+	* @return bool
+	* @access public
+	*/
+	public function is_enableable()
+	{
+		$config = $this->container->get('config');
+		return phpbb_version_compare($config['version'], '3.1.6', '>=');
+	}
 }


### PR DESCRIPTION
You don't need to check if in phpbb in only classes files-

Now checks if the phpBB version is 3.1.6 or greater else doesn't run the migrations. Tells the user within a nice error message box.
Here you should check also if PHP_VERSION fits the extension requirements stated in composer.json.
